### PR TITLE
Prepare for Uint8List SDK breaking change

### DIFF
--- a/lib/garage_client.dart
+++ b/lib/garage_client.dart
@@ -73,7 +73,7 @@ class GarageClient {
   static Future<String> purseToJson(HttpClientResponse response) async {
     var json = "";
     await for (var contents
-        in response.transform(utf8.decoder).transform(const LineSplitter())) {
+        in utf8.decoder.bind(response).transform(const LineSplitter())) {
       print(contents);
       json += contents;
     }


### PR DESCRIPTION
A recent change to the Dart SDK updated `HttpClientResponse`
to implement `Stream<Uint8List>` rather than implementing
`Stream<List<int>>`.

This forwards-compatible change updates calls to
`Stream.transform(StreamTransformer)` to instead call the
functionally equivalent `StreamTransformer.bind(Stream)`
API, which puts the stream in a covariant position and
thus causes the SDK change to be non-breaking.

https://github.com/dart-lang/sdk/issues/36900
